### PR TITLE
Rename Sirupsen/logrus to sirupsen/logrus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ cmd/**/cache/*
 cmd/**/*.pem
 cache/*
 tals/
+vendor/

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,7 +3,7 @@
 
 [[projects]]
   digest = "1:87c2e02fb01c27060ccc5ba7c5a407cc91147726f8f40b70cceeedbc52b1f3a8"
-  name = "github.com/Sirupsen/logrus"
+  name = "github.com/sirupsen/logrus"
   packages = ["."]
   pruneopts = "UT"
   revision = "e1e72e9de974bd926e5c56f83753fba2df402ce5"
@@ -265,7 +265,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
-    "github.com/Sirupsen/logrus",
+    "github.com/sirupsen/logrus",
     "github.com/cloudflare/gortr/prefixfile",
     "github.com/go-redis/redis",
     "github.com/golang/protobuf/proto",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -37,7 +37,7 @@
   version = "0.9.2"
 
 [[constraint]]
-  name = "github.com/Sirupsen/logrus"
+  name = "github.com/sirupsen/logrus"
   version = "1.3.0"
 
 [prune]

--- a/cmd/api-rrdp/rrdp.go
+++ b/cmd/api-rrdp/rrdp.go
@@ -13,7 +13,7 @@ import (
 
 	cfrpki "github.com/cloudflare/cfrpki/sync/api"
 	"github.com/cloudflare/cfrpki/sync/lib"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 )
 

--- a/cmd/api-rsync/rsync.go
+++ b/cmd/api-rsync/rsync.go
@@ -13,7 +13,7 @@ import (
 
 	cfrpki "github.com/cloudflare/cfrpki/sync/api"
 	"github.com/cloudflare/cfrpki/sync/lib"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 )
 

--- a/cmd/api-validator/validator.go
+++ b/cmd/api-validator/validator.go
@@ -5,7 +5,7 @@ import (
 	"github.com/cloudflare/cfrpki/validator/pki"
 	"github.com/cloudflare/cfrpki/validator/lib"
     "github.com/cloudflare/cfrpki/sync/api"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"strings"
 	"runtime"

--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -13,7 +13,7 @@ import (
 	"net"
 	"time"
 	"github.com/go-redis/redis"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 )
 

--- a/cmd/localrpki/localrpki.go
+++ b/cmd/localrpki/localrpki.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cloudflare/cfrpki/validator/pki"
 	"github.com/cloudflare/cfrpki/validator/lib"
 	"github.com/cloudflare/cfrpki/sync/lib"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"os"
 	"runtime"

--- a/cmd/octorpki/octorpki.go
+++ b/cmd/octorpki/octorpki.go
@@ -29,7 +29,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/cloudflare/gortr/prefixfile"
 	"github.com/gorilla/mux"
 )


### PR DESCRIPTION
As indicated at the top of the README.md in the
github.com/sirupsen/logrus package, there are issues with
case-sensitivity for this package -- most notably on MacOS where the
HFS+ filesystem is case-insensitive by default. This produces problems
when locally there is a directory called "Sirupsen" and one called
"sirupsen", especially if you are syncing files between machines.

https://github.com/sirupsen/logrus/blob/master/README.md shows that the
recommended spelling is the one that this change makes.