### PR TITLE
Handle default Mac OS version #27: remove --delete-delay

### DIFF
--- a/sync/lib/rsync.go
+++ b/sync/lib/rsync.go
@@ -70,7 +70,7 @@ func (s *RsyncSystem) RunRsync(ctx context.Context, uri string, bin string, dirP
 		return nil, err
 	}
 
-	cmd := exec.CommandContext(ctx, bin, "-var", "--delete-delay", uri, dirPath)
+	cmd := exec.CommandContext(ctx, bin, "-var", uri, dirPath)
 	if s.Log != nil {
 		s.Log.Debugf("Command ran: %v", cmd)
 	}


### PR DESCRIPTION
Mac OS default rsync version is 2.6.9 and dates from 2006.
The `--delete-delay` flag appears in version 3 (2008).

Since we only need the output of the CLI (the flag makes rsync delete the files at the end), removes this option.