### PR TITLE
Optimization for #30: Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,6 @@ USER rpki
 COPY --from=builder ${src_dir}/octorpki ${src_dir}/cmd/octorpki/private.pem /
 COPY --from=builder ${src_dir}/cmd/octorpki/tals /tals
 
-VOLUME ["/tals"]
+VOLUME ["/cache"]
 
 ENTRYPOINT ["./octorpki"]

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -19,6 +19,6 @@ COPY --from=builder /go/bin/octorpki /
 COPY cmd/octorpki/private.pem /
 COPY cmd/octorpki/tals /tals
 
-VOLUME ["/tals"]
+VOLUME ["/cache"]
 
 ENTRYPOINT ["./octorpki"]

--- a/README.md
+++ b/README.md
@@ -101,9 +101,9 @@ $ ./octorpki -h
 It is also available as a docker container. Do not forget to add the TAL files in the `tals/` folder.
 
 ```
-$ mkdir tals && mkdir cache && touch rrdp.json
-$ chmod 770 -R tals && chmod 770 -R cache && chmod 770 rrdp.json
-$ docker run -ti --net=host -v $PWD/tals:/tals -v $PWD/cache:/cache -v $PWD/rrdp.json:/rrdp.json -p 8080:8080 cloudflare/octorpki
+$ mkdir tals && mkdir cache && touch cache/rrdp.json
+$ chmod 770 -R tals && chmod 770 -R cache && chmod 770 cache/rrdp.json
+$ docker run -ti --net=host -v $PWD/tals:/tals -v $PWD/cache:/cache -p 8080:8080 cloudflare/octorpki
 ```
 
 Depending on your Docker configuration, you may need to set `--net=host` and set permissions for the files in order to avoid some errors.
@@ -112,7 +112,7 @@ Using the default settings, you can access the generated ROAs list on
 http://localhost:8080/output.json.
 Statistics are available on http://localhost:8080/infos in JSON.
 You can also plug a Prometheus server on the metrics endpoint http://localhost:8080/metrics.
-The current state of RRDP fetch will be stored in rrdp.json file.
+The current state of RRDP fetch will be stored in cache/rrdp.json file.
 
 #### [GoRTR](https://github.com/cloudflare/gortr)
 

--- a/cmd/octorpki/octorpki.go
+++ b/cmd/octorpki/octorpki.go
@@ -61,7 +61,7 @@ var (
 
 	// RRDP Options
 	RRDP     = flag.Bool("rrdp", true, "Enable RRDP fetching")
-	RRDPFile = flag.String("rrdp.file", "rrdp.json", "Save RRDP state")
+	RRDPFile = flag.String("rrdp.file", "cache/rrdp.json", "Save RRDP state")
 	RRDPMode = flag.Int("rrdp.mode", RRDP_MATCH_RSYNC, fmt.Sprintf("RRDP security mode (%v = no check, %v = match rsync domain, %v = match path)",
 		RRDP_NO_MATCH, RRDP_MATCH_RSYNC, RRDP_MATCH_STRICT))
 
@@ -856,6 +856,11 @@ func main() {
 	}
 	timeoutDur, _ := time.ParseDuration(*RsyncTimeout)
 	timeValidity, _ := time.ParseDuration(*Validity)
+
+	err := os.MkdirAll(*Basepath, os.ModePerm)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	s := &state{
 		Basepath:     *Basepath,


### PR DESCRIPTION
Changes the default rrdp.json location to cache
Change the Dockerfile default volume from tals to cache