### PR TITLE
Fix boot segfault by not ignoring PEM parsing errors

### DIFF
--- a/cmd/octorpki/octorpki.go
+++ b/cmd/octorpki/octorpki.go
@@ -170,9 +170,14 @@ type RRDPInfo struct {
 	Serial    int64  `json:"serial"`
 }
 
+var errKeyNotParsed = fmt.Errorf("Failed to PEM decode key")
+
 func ReadKey(key []byte, isPem bool) (*ecdsa.PrivateKey, error) {
 	if isPem {
 		block, _ := pem.Decode(key)
+		if block == nil {
+			return nil, errKeyNotParsed
+		}
 		key = block.Bytes
 	}
 


### PR DESCRIPTION
If a -output.sign.key is set, but unreadable, The program will segfault, this is because the error condition on parsing the PEM is not checked.

This issue was mentioned by @sysvinit on IRC

```
$ go/bin/octorpki -output.sign.key /dev/null                                                                                                        
22:15:30 <xxx> INFO[0000] Validator started                            
22:15:32 <xxx> panic: runtime error: invalid memory address or nil pointer dereference
22:15:34 <xxx> [signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x7ea20b]
22:15:36 <xxx> goroutine 1 [running]:
22:15:38 <xxx> main.ReadKey(0xc00015e000, 0x0, 0x200, 0x1, 0x200, 0x0, 0x0)
22:15:40 <xxx>  /home/xxx/go/src/github.com/cloudflare/cfrpki/cmd/octorpki/octorpki.go:176 +0xbb
22:15:42 <xxx> main.main()
22:15:44 <xxx>  /home/xxx/go/src/github.com/cloudflare/cfrpki/cmd/octorpki/octorpki.go:919 +0x1dba
```