### PR TITLE
Fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ BUILDINFOSDET ?=
 
 DOCKER_REPO   := cloudflare/
 OCTORPKI_NAME    := octorpki
-OCTORPKI_VERSION := $(shell git describe --tags $(git rev-list --tags --max-count=1))
+OCTORPKI_VERSION := $(shell git describe)
 VERSION_PKG   := $(shell echo $(OCTORPKI_VERSION) | sed 's/^v//g')
 ARCH          := x86_64
 LICENSE       := BSD-3


### PR DESCRIPTION
Background:

When octorpki is built using the Makefile, the version number to be used in the binary itself `octorpki -version` and the version used for the package file (rpm etc) is based off of the output of `git` commands.

Specifically:

`OCTORPKI_VERSION := $(shell git describe --tags $(git rev-list --tags --max-count=1))`

The intent of the above is to store the lastest tag in the OCTORPKI_VERSION variable. For example, `v1.1.4`. However, this doesn't account for people that are trying to build off master, where it would be more appropriate to use `git describe` to store the version as something like `v1.1.4-54-g50c7901` showing that we are 54 commits ahead of the last tag at commit 50c7901.

It turns out that the existing implementation is simply calling `git describe --tags` anyway. This is due to variable expansion, the `$(git rev-list --tags --max-count=1)` is expanded within the makefile and evaluates to nil.

For the above to work as expected it either needs to be ````$(shell git describe --tags `git rev-list --tags --max-count=1`)```` OR `$(shell git describe --tags $(shell git rev-list --tags --max-count=1))` However, this is unnecessary, `git describe` will give the desired result of outputting just the tag number if we have the tag checked out, or adding more info if we are ahead of the latest tag.

This pull request updated the Makefile to reflect what is actually happening on the command line, and in line with what should be happening regarding versioning when building off a commit that is ahead of the latest tag. 