### PR TITLE
Improvement of certificate logging conflict

### DIFF
--- a/validator/pki/pki.go
+++ b/validator/pki/pki.go
@@ -393,14 +393,16 @@ func (v *Validator) AddCert(cert *librpki.RPKI_Certificate, trust bool) (bool, [
 	ski := string(cert.Certificate.SubjectKeyId)
 	aki := string(cert.Certificate.AuthorityKeyId)
 
-	_, exists := v.Objects[ski]
+	res := ObjectToResource(cert)
+
+	conflict, exists := v.Objects[ski]
 	if exists {
-		return false, nil, nil, NewCertificateErrorConflict(cert)
+		conflictCert, _ := conflict.Resource.(*librpki.RPKI_Certificate)
+		return false, nil, res, NewCertificateErrorConflict(cert, conflictCert)
 	}
 
 	_, hasParentValid := v.ValidObjects[aki]
 	parent, hasParent := v.Objects[aki]
-	res := ObjectToResource(cert)
 	res.Parent = parent
 
 	var valid bool


### PR DESCRIPTION
When two certificates in the same "tree" have the same Subject Key ID: there is a conflict.
The error logged didn't have the proper structure and resulted in less information in Sentry.
This PR fixes that.

<img width="851" alt="Screen Shot 2020-07-29 at 6 19 44 PM" src="https://user-images.githubusercontent.com/27725238/88819083-2dc87e00-d1c8-11ea-9370-dd8d37623c4c.png">
