### PR TITLE
Add invalid signature check

### DIFF
--- a/cmd/localrpki/localrpki.go
+++ b/cmd/localrpki/localrpki.go
@@ -20,6 +20,7 @@ var (
 	RootTAL     = flag.String("tal.root", "tals/apnic.tal", "List of TAL separated by comma")
 	MapDir      = flag.String("map.dir", "rsync://rpki.ripe.net/repository/=./rpki.ripe.net/repository/", "Map of the paths separated by commas")
 	UseManifest = flag.Bool("manifest.use", true, "Use manifests file to explore instead of going into the repository")
+	CmsStrict   = flag.Bool("cms.strict", false, "Decode CMS with strict settings")
 	ValidTime   = flag.String("valid.time", "now", "Validation time (now/timestamp/RFC3339)")
 	LogLevel    = flag.String("loglevel", "info", "Log level")
 	Output      = flag.String("output", "output.json", "Output file")
@@ -69,6 +70,8 @@ func main() {
 	for _, tal := range rootTALs {
 		validator := pki.NewValidator()
 		validator.Time = vt
+
+		validator.DecoderConfig.ValidateStrict = *CmsStrict
 
 		manager := pki.NewSimpleManager()
 		manager.Validator = validator

--- a/cmd/octorpki/octorpki.go
+++ b/cmd/octorpki/octorpki.go
@@ -54,6 +54,7 @@ var (
 	Basepath    = flag.String("cache", "cache/", "Base directory to store certificates")
 	LogLevel    = flag.String("loglevel", "info", "Log level")
 	Refresh     = flag.String("refresh", "20m", "Revalidation interval")
+	CmsStrict   = flag.Bool("cms.strict", false, "Decode CMS with strict settings")
 
 	// Rsync Options
 	RsyncTimeout = flag.String("rsync.timeout", "20m", "Rsync command timeout")
@@ -792,6 +793,7 @@ func (s *state) MainValidation(pSpan opentracing.Span) {
 		tSpan.SetTag("tal", tal.Path)
 
 		validator := pki.NewValidator()
+		validator.DecoderConfig.ValidateStrict = *CmsStrict
 
 		sm := pki.NewSimpleManager()
 		manager[i] = sm

--- a/validator/lib/cms.go
+++ b/validator/lib/cms.go
@@ -326,7 +326,6 @@ func (cms *CMS) CheckSignaturesMatch() (bool, error) {
 	} else {
 		return false, nil
 	}
-	return false, nil
 }
 
 // Won't validate if signedattributes is empty

--- a/validator/lib/cms.go
+++ b/validator/lib/cms.go
@@ -277,6 +277,58 @@ func (cms *CMS) AddCRLs(crls []byte) error {
 	return nil
 }
 
+// Checks for an explicit NULL object in AlgorithmIdentifier
+// for both CMS and EE certificate.
+func (cms *CMS) CheckSignaturesMatch() (bool, error) {
+
+	type tbsCertificate struct {
+		Raw                asn1.RawContent
+		Version            int `asn1:"optional,explicit,default:0,tag:0"`
+		SerialNumber       asn1.RawValue
+		SignatureAlgorithm asn1.RawValue
+	}
+
+	type certificate struct {
+		Raw                asn1.RawContent
+		TBSCertificate     tbsCertificate
+		SignatureAlgorithm asn1.RawValue
+	}
+
+	var cert certificate
+
+	_, err := asn1.Unmarshal(cms.SignedData.Certificates.Bytes, &cert)
+	if err != nil {
+		return false, err
+	}
+	if len(cms.SignedData.SignerInfos) > 0 {
+
+		var signatureCert []asn1.RawValue
+		_, err = asn1.Unmarshal(cert.TBSCertificate.SignatureAlgorithm.FullBytes, &signatureCert)
+		if err != nil {
+			return false, err
+		}
+		if len(signatureCert) == 0 {
+			return false, nil
+		}
+
+		last := signatureCert[len(signatureCert)-1]
+		if last.Tag != asn1.TagNull {
+			return false, nil
+		}
+
+		var signatureCms []asn1.RawValue
+		_, err = asn1.Unmarshal(cms.SignedData.SignerInfos[0].SignatureAlgorithm.FullBytes, &signatureCms)
+		if err != nil {
+			return false, err
+		}
+
+		return bytes.Equal(cert.TBSCertificate.SignatureAlgorithm.FullBytes, cms.SignedData.SignerInfos[0].SignatureAlgorithm.FullBytes), nil
+	} else {
+		return false, nil
+	}
+	return false, nil
+}
+
 // Won't validate if signedattributes is empty
 func (cms *CMS) Validate(encap []byte, cert *x509.Certificate) error {
 	signedAttributes := cms.SignedData.SignerInfos[0].SignedAttrs
@@ -517,6 +569,5 @@ func DecodeCMS(data []byte) (*CMS, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	return &c, nil
 }

--- a/validator/lib/manifest.go
+++ b/validator/lib/manifest.go
@@ -2,6 +2,7 @@ package librpki
 
 import (
 	"encoding/asn1"
+	"errors"
 	"math/big"
 	"time"
 )
@@ -60,9 +61,23 @@ func EncodeManifestContent(eContent ManifestContent) (*Manifest, error) {
 }
 
 func DecodeManifest(data []byte) (*RPKIManifest, error) {
+	return DefaultDecoderConfig.DecodeManifest(data)
+}
+
+func (cf *DecoderConfig) DecodeManifest(data []byte) (*RPKIManifest, error) {
 	c, err := DecodeCMS(data)
 	if err != nil {
 		return nil, err
+	}
+
+	if cf.ValidateStrict {
+		vs, err := c.CheckSignaturesMatch()
+		if err != nil {
+			return nil, err
+		}
+		if !vs {
+			return nil, errors.New("CMS is not valid due to ")
+		}
 	}
 
 	var manifest Manifest

--- a/validator/lib/roa.go
+++ b/validator/lib/roa.go
@@ -223,10 +223,34 @@ func ConvertROAEntries(roacontent ROAContent) ([]*ROAEntry, int, error) {
 	return entries, asn, nil
 }
 
+type DecoderConfig struct {
+	ValidateStrict bool
+}
+
+var (
+	DefaultDecoderConfig = &DecoderConfig{
+		ValidateStrict: false,
+	}
+)
+
 func DecodeROA(data []byte) (*RPKIROA, error) {
+	return DefaultDecoderConfig.DecodeROA(data)
+}
+
+func (cf *DecoderConfig) DecodeROA(data []byte) (*RPKIROA, error) {
 	c, err := DecodeCMS(data)
 	if err != nil {
 		return nil, err
+	}
+
+	if cf.ValidateStrict {
+		vs, err := c.CheckSignaturesMatch()
+		if err != nil {
+			return nil, err
+		}
+		if !vs {
+			return nil, errors.New("CMS is not valid due to ")
+		}
 	}
 
 	var rawroa ROA

--- a/validator/pki/pki.go
+++ b/validator/pki/pki.go
@@ -198,6 +198,8 @@ type Validator struct {
 	ValidManifest map[string]*Resource // Make sure EE certificates are unique for a ROA
 	Manifest      map[string]*Resource
 
+	DecoderConfig *librpki.DecoderConfig
+
 	Time time.Time
 }
 
@@ -219,6 +221,8 @@ func NewValidator() *Validator {
 
 		ValidManifest: make(map[string]*Resource),
 		Manifest:      make(map[string]*Resource),
+
+		DecoderConfig: librpki.DefaultDecoderConfig,
 
 		Time: time.Now().UTC(),
 	}
@@ -296,7 +300,7 @@ func (v *Validator) AddResource(pkifile *PKIFile, data []byte) (bool, []*PKIFile
 		}
 		return valid, pathCert, res, err
 	case TYPE_ROA:
-		roa, err := librpki.DecodeROA(data)
+		roa, err := v.DecoderConfig.DecodeROA(data)
 		if err != nil {
 			return false, nil, nil, err
 		}
@@ -307,7 +311,7 @@ func (v *Validator) AddResource(pkifile *PKIFile, data []byte) (bool, []*PKIFile
 		res.File = pkifile
 		return valid, nil, res, err
 	case TYPE_MFT:
-		mft, err := librpki.DecodeManifest(data)
+		mft, err := v.DecoderConfig.DecodeManifest(data)
 		if err != nil {
 			return false, nil, nil, err
 		}


### PR DESCRIPTION
Should fix #66

Adds flag `-cms.strict` which is false by default.

To test with the August 13th dump [here](https://github.com/cloudflare/cfrpki/issues/66#issuecomment-673534371).
```
$ go run localrpki.go -tal.root tals/arin.tal -map.dir rsync://=path-to-arin-repo/ -loglevel debug -valid.time "2020-08-13T01:00:00Z" -cms.strict=true
```