### PR TITLE
fix debian packaging bug with no default config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,6 @@ package-deb-octorpki: prepare
         --url "$(URL)" \
         --architecture $(ARCH) \
         --license "$(LICENSE)" \
-       	--deb-no-default-config-files \
         --package $(DIST_DIR) \
         $(OUTPUT_OCTORPKI)=/usr/bin/octorpki \
         package/octorpki.service=/lib/systemd/system/octorpki.service \


### PR DESCRIPTION
Would erase default configuration file without it. Noticed in #75 