### PR TITLE
validator/lib: fix dropped errors

### DIFF
--- a/validator/lib/cert.go
+++ b/validator/lib/cert.go
@@ -343,6 +343,9 @@ func DecodeIPAddressBlock(data []byte) ([]IPCertificateInformation, error) {
 
 					a, _ := DecodeIPMinMax(ipaddrfam.AddressFamily, addrRange.Min, false)
 					b, err := DecodeIPMinMax(ipaddrfam.AddressFamily, addrRange.Max, true)
+					if err != nil {
+						return ipaddresses, err
+					}
 					ipaddresses = append(ipaddresses, &IPAddressRange{
 						Min: a,
 						Max: b,

--- a/validator/lib/cms.go
+++ b/validator/lib/cms.go
@@ -221,7 +221,9 @@ func (cms *CMS) Sign(rand io.Reader, ski []byte, encap []byte, priv interface{},
 	h.Write(encap)
 	messageDigest := h.Sum(nil)
 	messageDigestEnc, err := asn1.Marshal(messageDigest)
-
+	if err != nil {
+		return err
+	}
 	digestAttribute := Attribute{
 		AttrType:  MessageDigest,
 		AttrValue: []asn1.RawValue{asn1.RawValue{FullBytes: messageDigestEnc}},

--- a/validator/lib/manifest_test.go
+++ b/validator/lib/manifest_test.go
@@ -7,10 +7,12 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/asn1"
-	"github.com/stretchr/testify/assert"
 	"math/big"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func MakeMFTContent() ManifestContent {
@@ -50,6 +52,7 @@ func TestEncodeMFTContent(t *testing.T) {
 	assert.Nil(t, err)
 
 	privkey, err := rsa.GenerateKey(rand.Reader, 1024)
+	require.NoError(t, err)
 	ski := []byte{1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 1, 2, 3, 4, 5}
 
 	cert := &x509.Certificate{
@@ -64,6 +67,7 @@ func TestEncodeMFTContent(t *testing.T) {
 	}
 	pubkey := privkey.Public()
 	certBytes, err := x509.CreateCertificate(rand.Reader, cert, cert, pubkey, privkey)
+	require.NoError(t, err)
 
 	encap, _ := EContentToEncap(contentEnc.EContent.FullBytes)
 	err = cms.Sign(rand.Reader, ski, encap, privkey, certBytes)

--- a/validator/lib/roa.go
+++ b/validator/lib/roa.go
@@ -255,7 +255,9 @@ func (cf *DecoderConfig) DecodeROA(data []byte) (*RPKIROA, error) {
 
 	var rawroa ROA
 	_, err = asn1.Unmarshal(c.SignedData.EncapContentInfo.FullBytes, &rawroa)
-
+	if err != nil {
+		return nil, err
+	}
 	var inner asn1.RawValue
 	_, err = asn1.Unmarshal(rawroa.EContent.Bytes, &inner)
 	if err != nil {

--- a/validator/lib/roa_test.go
+++ b/validator/lib/roa_test.go
@@ -6,11 +6,13 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/asn1"
-	"github.com/stretchr/testify/assert"
 	"math/big"
 	"net"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func MakeROAEntries() []*ROAEntry {
@@ -41,6 +43,7 @@ func TestEncodeROA(t *testing.T) {
 	assert.Nil(t, err)
 
 	privkey, err := rsa.GenerateKey(rand.Reader, 1024)
+	require.NoError(t, err)
 	ski := []byte{1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 1, 2, 3, 4, 5}
 
 	cert := &x509.Certificate{
@@ -55,6 +58,7 @@ func TestEncodeROA(t *testing.T) {
 	}
 	pubkey := privkey.Public()
 	certBytes, err := x509.CreateCertificate(rand.Reader, cert, cert, pubkey, privkey)
+	require.NoError(t, err)
 
 	encap, _ := EContentToEncap(entriesEnc.EContent.FullBytes)
 	err = cms.Sign(rand.Reader, ski, encap, privkey, certBytes)

--- a/validator/lib/xml_test.go
+++ b/validator/lib/xml_test.go
@@ -7,11 +7,13 @@ import (
 	"crypto/x509/pkix"
 	"encoding/asn1"
 	"encoding/hex"
-	"github.com/stretchr/testify/assert"
 	"math/big"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEncodeXMLContent(t *testing.T) {
@@ -24,6 +26,7 @@ func TestEncodeXMLContent(t *testing.T) {
 	assert.Nil(t, err)
 
 	privkeyParent, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
 	skiParent, _ := HashRSAPublicKey(*privkeyParent.Public().(*rsa.PublicKey))
 
 	parentCert := &x509.Certificate{
@@ -38,6 +41,7 @@ func TestEncodeXMLContent(t *testing.T) {
 	}
 
 	privkey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
 	ski, _ := HashRSAPublicKey(*privkey.Public().(*rsa.PublicKey))
 
 	cert := &x509.Certificate{
@@ -52,6 +56,7 @@ func TestEncodeXMLContent(t *testing.T) {
 	}
 	pubkey := privkey.Public()
 	certBytes, err := x509.CreateCertificate(rand.Reader, cert, parentCert, pubkey, privkeyParent)
+	require.NoError(t, err)
 
 	crls, err := parentCert.CreateCRL(rand.Reader, privkeyParent, []pkix.RevokedCertificate{}, now.Add(-time.Minute*5), now.Add(time.Minute*5))
 	assert.Nil(t, err)


### PR DESCRIPTION
This fixes multiple code and test errors that were being dropped in `validator/lib`.

I'd like to go one step further with another PR to replace the use of `assert.Nil()` for error testing with the better `require.NoError()`, would that be welcome?