### PR TITLE
Issue #95: Fix invalid manifests

### DIFF
--- a/validator/pki/pki.go
+++ b/validator/pki/pki.go
@@ -7,8 +7,9 @@ import (
 	"encoding/asn1"
 	"errors"
 	"fmt"
-	"github.com/cloudflare/cfrpki/validator/lib"
 	"time"
+
+	"github.com/cloudflare/cfrpki/validator/lib"
 )
 
 const (
@@ -873,6 +874,22 @@ func (sm *SimpleManager) Explore(notMFT bool, addInvalidChilds bool) int {
 			data, err := sm.GetNextFile(file)
 
 			if err == nil && data != nil && sm.StrictHash && data.Sha256 != nil && file.ManifestHash != nil {
+				// Invalidates the Manifests' CA when the manifest is expired
+				if file.Parent != nil && file.Parent.Type == TYPE_MFT {
+					res, ok := sm.ResourceOfPath[file.Parent]
+					if ok && res != nil && res.Resource != nil {
+						cert, ok := res.Resource.(*librpki.RPKIManifest)
+						if ok {
+							if time.Now().After(cert.Content.NextUpdate) || time.Now().Before(cert.Content.ThisUpdate) {
+								sm.InvalidateManifestParent(file, nil)
+							}
+						} else {
+							sm.Log.Debugf("Resource is not a manifest, not invalidating")
+						}
+					} else {
+						sm.Log.Debugf("Could not fetch Parent Resource, not invalidating")
+					}
+				}
 				if bytes.Compare(data.Sha256, file.ManifestHash) != 0 {
 					errHash := NewResourceErrorHash(data.Sha256, file.ManifestHash)
 					errHash.AddFileErrorInfo(file, data)
@@ -889,7 +906,6 @@ func (sm *SimpleManager) Explore(notMFT bool, addInvalidChilds bool) int {
 				}
 
 			}
-
 			if err != nil {
 				sm.reportErrorFile(err, file, data)
 


### PR DESCRIPTION
As discovered by @job, the validator was not validating the NextUpdate property of the Manifest files. This caused stale information to be validated.
This patch checks if the RPKI Manifest NextUpdate is in the future, and not the past. If it's in the past, we invalidate the Parent of the Manifest.