### PR TITLE
Typo fix for after-install-octorpki.sh

### DIFF
--- a/package/after-install-octorpki.sh
+++ b/package/after-install-octorpki.sh
@@ -3,7 +3,7 @@
 set -x
 
 addgroup --system octorpki
-adduser --system --home /var/lib/octorpki --shell /usr/sbin/nologin --disable-login --group octorpki
+adduser --system --home /var/lib/octorpki --shell /usr/sbin/nologin --disabled-login --group octorpki
 
 systemctl daemon-reload
 systemctl enable octorpki.service


### PR DESCRIPTION
`man adduser` says:

```
--disabled-login
          Do not run passwd to set the password.  The user won't be able 
          to use  her  account until the password is set.
```