### PR TITLE
Fixing race condition in MainValidation

### DIFF
--- a/cmd/octorpki/octorpki.go
+++ b/cmd/octorpki/octorpki.go
@@ -828,7 +828,7 @@ func (s *state) MainValidation(pSpan opentracing.Span) {
 		manager[i].StrictHash = s.StrictHash
 		manager[i].StrictManifests = s.StrictManifests
 
-		go func(sm *pki.SimpleManager) {
+		go func(sm *pki.SimpleManager, tal *pki.PKIFile) {
 			for err := range sm.Errors {
 				tSpan.SetTag("error", true)
 				tSpan.LogKV("event", "resource issue", "type", "skipping resource", "message", err)
@@ -844,7 +844,7 @@ func (s *state) MainValidation(pSpan opentracing.Span) {
 			}
 
 			//log.Warn("Closed errors")
-		}(sm)
+		}(sm, tal)
 		manager[i].AddInitial([]*pki.PKIFile{tal})
 		s.CountExplore = manager[i].Explore(!s.UseManifest, false)
 


### PR DESCRIPTION
Fixing this race condition:
```
==================
WARNING: DATA RACE
Write at 0x00c000010008 by main goroutine:
  main.(*state).MainValidation()
      /home/takt/git/src/github.com/cloudflare/cfrpki/cmd/octorpki/octorpki.go:812 +0x485
  main.main()
      /home/takt/git/src/github.com/cloudflare/cfrpki/cmd/octorpki/octorpki.go:1374 +0x38f3

Previous read at 0x00c000010008 by goroutine 78:
  main.(*state).MainValidation.func1.1()
      /home/takt/git/src/github.com/cloudflare/cfrpki/cmd/octorpki/octorpki.go:841 +0x84
  github.com/getsentry/sentry-go.(*Hub).WithScope()
      /home/takt/go/pkg/mod/github.com/getsentry/sentry-go@v0.11.0/hub.go:189 +0x95
  github.com/getsentry/sentry-go.WithScope()
      /home/takt/go/pkg/mod/github.com/getsentry/sentry-go@v0.11.0/sentry.go:89 +0x12b
  main.(*state).MainValidation.func1()
      /home/takt/git/src/github.com/cloudflare/cfrpki/cmd/octorpki/octorpki.go:837 +0xce
  main.(*state).MainValidation·dwrap·7()
      /home/takt/git/src/github.com/cloudflare/cfrpki/cmd/octorpki/octorpki.go:847 +0x47

Goroutine 78 (finished) created at:
  main.(*state).MainValidation()
      /home/takt/git/src/github.com/cloudflare/cfrpki/cmd/octorpki/octorpki.go:831 +0xd7b
  main.main()
      /home/takt/git/src/github.com/cloudflare/cfrpki/cmd/octorpki/octorpki.go:1374 +0x38f3
==================
```