### PR TITLE
Fix assumption about trailing slash in -cache paramater

### DIFF
--- a/sync/lib/fetch.go
+++ b/sync/lib/fetch.go
@@ -2,12 +2,14 @@ package syncpki
 
 import (
 	"crypto/sha256"
-	"github.com/cloudflare/cfrpki/validator/lib"
-	"github.com/cloudflare/cfrpki/validator/pki"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"strings"
 	"time"
+
+	librpki "github.com/cloudflare/cfrpki/validator/lib"
+	"github.com/cloudflare/cfrpki/validator/pki"
 )
 
 type LocalFetch struct {
@@ -28,8 +30,14 @@ func (s *LocalFetch) SetRepositories(repositories map[string]time.Time) {
 	s.repositories = repositories
 }
 
-func ReplaceString(pathRep string, replace map[string]string) string {
+func GetLocalPath(pathRep string, replace map[string]string) string {
+	sep := fmt.Sprintf("%c", os.PathSeparator)
+
 	for repKey, repVal := range replace {
+		if !strings.HasSuffix(repVal, sep) {
+			repVal += sep
+		}
+
 		pathRep = strings.Replace(pathRep, repKey, repVal, -1)
 	}
 	return pathRep
@@ -37,7 +45,7 @@ func ReplaceString(pathRep string, replace map[string]string) string {
 
 func ReplacePath(file *pki.PKIFile, replace map[string]string) string {
 	pathRep := file.ComputePath()
-	pathRep = ReplaceString(pathRep, replace)
+	pathRep = GetLocalPath(pathRep, replace)
 	return pathRep
 }
 
@@ -113,7 +121,7 @@ func (s *LocalFetch) GetFileConv(file *pki.PKIFile, convert bool) (*pki.SeekFile
 }
 
 func (s *LocalFetch) GetRepository(file *pki.PKIFile, callback pki.CallbackExplore) error {
-	newPath := ReplaceString(file.Repo, s.MapDirectory)
+	newPath := GetLocalPath(file.Repo, s.MapDirectory)
 	repoFile, err := os.Open(newPath)
 	if err != nil {
 		return err

--- a/sync/lib/fetch_test.go
+++ b/sync/lib/fetch_test.go
@@ -1,0 +1,38 @@
+package syncpki
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetLocalPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		pathRep  string
+		replace  map[string]string
+		expected string
+	}{
+		{
+			name:    "With trailing slash",
+			pathRep: "rsync://rpki.apnic.net/repository/apnic-rpki-root-iana-origin.cer",
+			replace: map[string]string{
+				"rsync://": "cache/",
+			},
+			expected: "cache/rpki.apnic.net/repository/apnic-rpki-root-iana-origin.cer",
+		},
+		{
+			name:    "Without trailing slash (this is a regresion test)",
+			pathRep: "rsync://rpki.apnic.net/repository/apnic-rpki-root-iana-origin.cer",
+			replace: map[string]string{
+				"rsync://": "cache",
+			},
+			expected: "cache/rpki.apnic.net/repository/apnic-rpki-root-iana-origin.cer",
+		},
+	}
+
+	for _, test := range tests {
+		res := GetLocalPath(test.pathRep, test.replace)
+		assert.Equal(t, test.expected, res, test.name)
+	}
+}


### PR DESCRIPTION
Current implementation requires octorpki's -cache parameter to contain a trailing slash.
If it is missing it leads to exposure of empty ROA list. This PR fixes that issue.