### PR TITLE
Fixed regression to 'File not ready yet' state

### DIFF
--- a/cmd/octorpki/octorpki.go
+++ b/cmd/octorpki/octorpki.go
@@ -1267,6 +1267,7 @@ func (s *OctoRPKI) validationLoop() {
 			// GHSA-pmw9-567p-68pc: Do not crash when MaxIterations is reached
 			log.Warning("Max iterations has been reached. Defining current state as stable and stoppping deeper validation. This number can be adjusted with -max.iterations")
 			s.Stable.Store(true)
+			s.HasPreviousStable.Store(true)
 		}
 
 		if *Mode == "oneoff" && s.Stable.Load() {

--- a/cmd/octorpki/octorpki.go
+++ b/cmd/octorpki/octorpki.go
@@ -1251,7 +1251,9 @@ func (s *OctoRPKI) validationLoop() {
 		// Reduce
 		changed := s.MainReduce()
 		s.Stable.Store(!changed && s.stats.Iteration > 1)
-		s.HasPreviousStable.Store(s.Stable.Load())
+		if s.Stable.Load() {
+			s.HasPreviousStable.Store(s.Stable.Load())
+		}
 
 		if *Mode == "oneoff" && (s.Stable.Load() || !*WaitStable) {
 			s.mustOutput()


### PR DESCRIPTION
This PR fixes an issue that causes octorpki to return the 'File not ready yet' state after previously achieving a stable state.

There are two functions that lead me to believe reverting to the 'File not ready yet' state is not the intended behavior of octorpki. In both `ServeROAs` and `ServeHealth` the code checks for `s.Stable` and `s.HasPreviousStable`, seemingly to continue serving ROAs if the state was once stable but isn't currently. The only place `s.HasPreviousStable` is set is immediately after s.Stable is set on [octorpki.go#L1254](https://github.com/cloudflare/cfrpki/blob/5f64bcd13477b29cd7ddff6fff3c65dfac3423ca/cmd/octorpki/octorpki.go#L1254) so whenever `s.Stable` reverts to false after `s.MainReduce()` so will `s.HasPreviousStable`. Both `s.Stable` and `s.HasPreviousStable` being false will cause octorpki to revert to a state where no ROAs are served and instead a message is returned: 'File not ready yet'. `s.Stable` is also set after the validation interval expires but that will result in `s.HasPreviousStable` only being true for a single additional iteration, after which it may revert to false (based on the result of `s.MainReduce()`).

The fix adds check to only set `s.HasPreviousStable` when `s.Stable` is true.

While I was making this change I also noticed that `s.HasPreviousStable` isn't set after `MaxIterations` is reached which similarly would result in the ROA list switching back and forth between available and 'File not ready yet'. I updated that to also set `s.HasPreviousStable`.

Happy to make any adjustments to this PR as needed. Please let me know if I'm misunderstanding the intended use of `s.HasPreviousStable` at all. Thanks!