### PR TITLE
Fix octorpki -allow.root flag

### DIFF
--- a/cmd/octorpki/octorpki.go
+++ b/cmd/octorpki/octorpki.go
@@ -1089,10 +1089,6 @@ func (s *OctoRPKI) Serve(addr string, path string, metricsPath string, infoPath 
 }
 
 func init() {
-	if !*AllowRoot && runningAsRoot() {
-		panic("Running as root is not allowed by default")
-	}
-
 	prometheus.MustRegister(MetricSIACounts)
 	prometheus.MustRegister(MetricRsyncErrors)
 	prometheus.MustRegister(MetricRRDPErrors)
@@ -1116,6 +1112,10 @@ func main() {
 	if *Version {
 		fmt.Println(AppVersion)
 		os.Exit(0)
+	}
+
+	if !*AllowRoot && runningAsRoot() {
+		panic("Running as root is not allowed by default")
 	}
 
 	lvl, _ := log.ParseLevel(*LogLevel)


### PR DESCRIPTION
Commit c9544c992488 ("VULN-11642: Deny running as root by default", 2021-11-18) introduced the new flag -allow.root to the octorpki command, which should still allow it to run as root.

However, the flag has no effect because the check is performed before the command line flags are parsed. Delay the check so that it recognizes the flag correctly.