### PR TITLE
Allow prefixes longer than /28 or /48 by default

### DIFF
--- a/cmd/octorpki/filter.go
+++ b/cmd/octorpki/filter.go
@@ -3,7 +3,7 @@ package main
 import "github.com/cloudflare/gortr/prefixfile"
 
 func FilterInvalidPrefixLen(roalist []prefixfile.ROAJson) []prefixfile.ROAJson {
-	validROAs := make([]prefixfile.ROAJson, 0)
+	validROAs := make([]prefixfile.ROAJson, 0, len(roalist))
 	for _, roa := range roalist {
 		prefix := roa.GetPrefix()
 		prefixLen, _ := prefix.Mask.Size()
@@ -24,7 +24,7 @@ func FilterInvalidPrefixLen(roalist []prefixfile.ROAJson) []prefixfile.ROAJson {
 }
 
 func FilterDuplicates(roalist []prefixfile.ROAJson) []prefixfile.ROAJson {
-	roalistNodup := make([]prefixfile.ROAJson, 0)
+	roalistNodup := make([]prefixfile.ROAJson, 0, len(roalist))
 	existingsROAs := make(map[string]struct{})
 	for _, roa := range roalist {
 		k := roa.String()

--- a/cmd/octorpki/filter_test.go
+++ b/cmd/octorpki/filter_test.go
@@ -14,7 +14,7 @@ func TestFilter(t *testing.T) {
 		expected []prefixfile.ROAJson
 	}{
 		{
-			name: "Invalid IPv4 prefix",
+			name: "Likely unrouteable IPv4 prefix",
 			input: []prefixfile.ROAJson{
 				{
 					Prefix: "1.1.1.0/25",
@@ -25,7 +25,7 @@ func TestFilter(t *testing.T) {
 			expected: []prefixfile.ROAJson{},
 		},
 		{
-			name: "Invalid IPv6 prefix",
+			name: "Likely unrouteable IPv6 prefix",
 			input: []prefixfile.ROAJson{
 				{
 					Prefix: "2001:db8::/64",
@@ -65,7 +65,7 @@ func TestFilter(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		res := FilterInvalidPrefixLen(test.input)
+		res := FilterInvalidPrefixLen(test.input, 24, 48)
 		assert.Equal(t, test.expected, res, test.name)
 	}
 }

--- a/cmd/octorpki/octorpki.go
+++ b/cmd/octorpki/octorpki.go
@@ -52,7 +52,7 @@ var (
 	LogLevel      = flag.String("loglevel", "info", "Log level")
 	Refresh       = flag.Duration("refresh", time.Minute*20, "Revalidation interval")
 	MaxIterations = flag.Int("max.iterations", 32, "Specify the max number of iterations octorpki will make before failing to generate output.json")
-	Filter        = flag.Bool("filter", true, "Filter out non accessible prefixes and duplicates")
+	Filter        = flag.Bool("filter", false, "Filter out non-routable prefixes. Duplicates are always filtered.")
 
 	StrictManifests = flag.Bool("strict.manifests", true, "Manifests must be complete or invalidate CA")
 	StrictHash      = flag.Bool("strict.hash", true, "Check the hash of files")
@@ -1007,9 +1007,9 @@ func (s *OctoRPKI) generateROAList(pkiManagers []*pki.SimpleManager, span opentr
 
 	if s.Filter {
 		roalist.Data = FilterInvalidPrefixLen(FilterDuplicates(roalist.Data))
+	} else {
+		roalist.Data = filterDuplicates(roalist.Data)
 	}
-
-	roalist.Data = filterDuplicates(roalist.Data)
 	if *Sign {
 		s.signROAList(roalist, span)
 	}

--- a/validator/lib/roa.go
+++ b/validator/lib/roa.go
@@ -164,9 +164,9 @@ func (entry *ROAEntry) Validate() error {
 	}
 
 	if entry.IPNet.IP.To4() != nil && entry.MaxLength > 32 { // If IPv4
-		return fmt.Errorf("max length (%d) too small for IPv4 prefix", entry.MaxLength)
+		return fmt.Errorf("max length (%d) too large for IPv4 prefix", entry.MaxLength)
 	} else if entry.MaxLength > 128 { // If IPv6
-		return fmt.Errorf("max length (%d) too small for IPv6 prefix", entry.MaxLength)
+		return fmt.Errorf("max length (%d) too large for IPv6 prefix", entry.MaxLength)
 	}
 
 	return nil


### PR DESCRIPTION
I think that not filtering by default is better behaviour.

This commit changes the default for the prefix filtering behaviour to be off. This allows longer prefixes to pass by default.